### PR TITLE
sccorerr files are also added as content

### DIFF
--- a/build/pack.props
+++ b/build/pack.props
@@ -32,5 +32,7 @@
       <Pack>true</Pack>
       <PackagePath>files\sccoreerr\sccoreerr_gen.h</PackagePath>
     </None>
+    <Content Include="$(CFilePath)" Pack="true" PackagePath="contentFiles\any\any\sccoreerr_gen.c" PackageCopyToOutput="true" />
+    <Content Include="$(HFilePath)" Pack="true" PackagePath="contentFiles\any\any\sccoreerr_gen.h" PackageCopyToOutput="true" />
   </ItemGroup>
 </Project>

--- a/src/Starcounter.ErrorCodes/Starcounter.ErrorCodes.csproj
+++ b/src/Starcounter.ErrorCodes/Starcounter.ErrorCodes.csproj
@@ -11,7 +11,7 @@
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
 
     <!-- NOTE: VersionPrefix here should only contain Major.Minor version since the patchnúmber is calculated. -->
-    <VersionPrefix>0.14</VersionPrefix>
+    <VersionPrefix>0.15</VersionPrefix>
   </PropertyGroup>
 
   <Import Project="..\..\build\generate.props" />


### PR DESCRIPTION
**If** we merge this PR, then we need to update the versions where it is consumed to `0.15.*` as this bumps the Minor version (leave it if `0.*` is used)

**and**

add `<ExcludeAssets>contentFiles<ExcludeAssets>` tag as it includes `sccoreerr_gen.c`/`sccoreerr_gen.h` to the project and copies them to the output directory otherwise. 

```
<PackageReference Include="Starcounter.ErrorCodes" Version="0.*" >
  <ExcludeAssets>contentFiles</ExcludeAssets>
</PackageReference>
````