### PR TITLE
Workaround/fix for failure of resolving different versions of errorcodes from other packages

### DIFF
--- a/src/Starcounter.ErrorCodes/Starcounter.ErrorCodes.csproj
+++ b/src/Starcounter.ErrorCodes/Starcounter.ErrorCodes.csproj
@@ -6,6 +6,7 @@
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">$(TargetFrameworks);net45;net46</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AssemblyVersion>1.0.0</AssemblyVersion>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>

--- a/src/Starcounter.ErrorCodes/Starcounter.ErrorCodes.csproj
+++ b/src/Starcounter.ErrorCodes/Starcounter.ErrorCodes.csproj
@@ -12,7 +12,7 @@
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
 
     <!-- NOTE: VersionPrefix here should only contain Major.Minor version since the patchnúmber is calculated. -->
-    <VersionPrefix>0.15</VersionPrefix>
+    <VersionPrefix>0.16</VersionPrefix>
   </PropertyGroup>
 
   <Import Project="..\..\build\generate.props" />


### PR DESCRIPTION
Puts a hardcoded assemblyversion in place as a fix/workaround for problems with resolving versioned assemblies that have a strongname. Problem discussed in https://github.com/Starcounter/AdminTrack/issues/475.

The version of the package, and the stamped productversion on the assembly will still show the proper version though.

Only bumps minor version since it doesn't break compatibility.  

Integration build with these changes
2.4: https://teamcity.starcounter.org/viewLog.html?buildId=54977&tab=buildResultsDiv&buildTypeId=Bifrost_IntegrationSc24Windows
Nova (win): https://teamcity.starcounter.org/viewLog.html?buildId=54972&tab=buildResultsDiv&buildTypeId=Bifrost_IntegrationNovaWindows
Nova (linux): https://teamcity.starcounter.org/viewLog.html?buildId=54979&tab=buildResultsDiv&buildTypeId=Bifrost_IntegrationNovaLinux