### PR TITLE
Add some unit tests

### DIFF
--- a/src/Starcounter.ErrorCodes/ExceptionFactory.cs
+++ b/src/Starcounter.ErrorCodes/ExceptionFactory.cs
@@ -65,7 +65,7 @@ namespace Starcounter.ErrorCodes
                 throw new ArgumentNullException(nameof(messageFactory));
             }
 
-            // Not to be used when tranlating errors originating from the
+            // Not to be used when translating errors originating from the
             // database kernel since the exceptions set up to handle database
             // errors doesn't exist in this assembly.
 

--- a/src/Starcounter.ErrorCodes/ExceptionFactory.cs
+++ b/src/Starcounter.ErrorCodes/ExceptionFactory.cs
@@ -60,6 +60,11 @@ namespace Starcounter.ErrorCodes
             uint facilityCode;
             Exception ex;
 
+            if (messageFactory == null)
+            {
+                throw new ArgumentNullException(nameof(messageFactory));
+            }
+
             // Not to be used when tranlating errors originating from the
             // database kernel since the exceptions set up to handle database
             // errors doesn't exist in this assembly.

--- a/test/Starcounter.ErrorCodes.Tests/ExceptionFactoryTests.cs
+++ b/test/Starcounter.ErrorCodes.Tests/ExceptionFactoryTests.cs
@@ -1,0 +1,26 @@
+namespace Starcounter.ErrorCodes.Tests
+{
+    using System;
+    using Xunit;
+
+    public class ExceptionFactoryTests
+    {
+        public class TheCreateExceptionClass
+        {
+            [Fact]
+            public void ThrowsExceptionWhenMessageFactoryIsNull()
+            {
+                //Given
+                var factory = new ExceptionFactory();
+
+                //When
+                Action createException = () => factory.CreateException(0, null, null, null, null);
+
+                //Then
+                var e = Assert.Throws<ArgumentNullException>(createException);
+                Assert.NotEmpty(e.Message);
+                Assert.NotEmpty(e.ParamName);
+            }
+        }
+    }
+}

--- a/test/Starcounter.ErrorCodes.Tests/ExceptionFactoryTests.cs
+++ b/test/Starcounter.ErrorCodes.Tests/ExceptionFactoryTests.cs
@@ -1,6 +1,7 @@
 namespace Starcounter.ErrorCodes.Tests
 {
     using System;
+    using System.IO;
     using Xunit;
 
     public class ExceptionFactoryTests
@@ -20,6 +21,75 @@ namespace Starcounter.ErrorCodes.Tests
                 var e = Assert.Throws<ArgumentNullException>(createException);
                 Assert.NotEmpty(e.Message);
                 Assert.NotEmpty(e.ParamName);
+            }
+
+            [Fact]
+            public void ExceptionHasMessageCreatedByMessageFactory()
+            {
+                //Given
+                var factory = new ExceptionFactory();
+                var message = "MyMessage";
+                Func<uint, string, object[], string> messageFactory = (x, y, z) => message;
+
+                //When
+                var exception = factory.CreateException(0, null, null, messageFactory);
+
+                //Then
+                Assert.Equal(message, exception.Message);
+            }
+
+            [Fact]
+            public void ErrorCode3000CreatesIOException()
+            {
+                //Given
+                uint errorCode = 3000;
+                var factory = new ExceptionFactory();
+
+                //When
+                var exception = factory.CreateException(errorCode, null, null, (x, y, z) => "message");
+
+                //Then
+                Assert.IsType<IOException>(exception);
+            }
+
+            [Fact]
+            public void HadInnerExceptionSetIfInnerExceptionIsPassed()
+            {
+                //Given
+                var innerException = new Exception();
+                var factory = new ExceptionFactory();
+
+                //When
+                var exception = factory.CreateException(0, innerException, null, (y, z, x) => "message");
+
+                //Then
+                Assert.Equal(innerException, exception.InnerException);
+            }
+
+            [Fact]
+            public void HelpLinkIsSetForException()
+            {
+                //Given
+                var factory = new ExceptionFactory();
+
+                //When
+                var exception = factory.CreateException(0, null, null, (x, y, z) => "message");
+
+                //Then
+                Assert.NotEmpty(exception.HelpLink);
+            }
+
+            [Fact]
+            public void SourceIsSetForException()
+            {
+                //Given
+                var factory = new ExceptionFactory();
+
+                //When
+                var exception = factory.CreateException(0, null, null, (x, y, z) => "message");
+
+                //Then
+                Assert.NotEmpty(exception.Source);
             }
         }
     }

--- a/test/Starcounter.ErrorCodes.Tests/ExceptionFactoryTests.cs
+++ b/test/Starcounter.ErrorCodes.Tests/ExceptionFactoryTests.cs
@@ -15,7 +15,11 @@ namespace Starcounter.ErrorCodes.Tests
                 var factory = new ExceptionFactory();
 
                 //When
-                Action createException = () => factory.CreateException(0, null, null, null, null);
+                Action createException = () => factory.CreateException(
+                    0,
+                    new Exception(),
+                    "some string",
+                    null);
 
                 //Then
                 var e = Assert.Throws<ArgumentNullException>(createException);


### PR DESCRIPTION
There are right now no tests for Starcounter.ErrorCodes. This makes it very hard to change. I added a couple of tests here to get started. It doesn't cover everything, but it's better than nothing.

Also, the `CreateException` method has too many parameters, you could remove `messagePostfix`, `messageArguments` and simplify the `messageFactory` delegate while maintaining the same functionality