### PR TITLE
Target only netstandard1.0 and fix some bugs

### DIFF
--- a/build/generate.targets
+++ b/build/generate.targets
@@ -16,7 +16,7 @@
 
   <Target Name="GenerateCode" BeforeTargets="BeforeBuild">
 	  <Exec
-      Command="dotnet run --no-build --project $(GeneratorProj) $(XmlSourceFile) --csharp $(CsFilePath) --c $(CFilePath) --header $(HFilePath) --count $(CountFilePath)"
+      Command="dotnet run --no-build --project $(GeneratorProj) $(XmlSourceFile)  --verbose --csharp $(CsFilePath) --c $(CFilePath) --header $(HFilePath) --count $(CountFilePath)"
       Outputs="$(CsFilePath);$(CFilePath);$(HFilePath)"
       ContinueOnError="False"
     />

--- a/src/Starcounter.ErrorCodes.Generator/CommandLineInterface.cs
+++ b/src/Starcounter.ErrorCodes.Generator/CommandLineInterface.cs
@@ -122,7 +122,7 @@ namespace Starcounter.ErrorCodes.Generator
 
             if (countOption.HasValue())
             {
-                Verbose("Writing errorcode count to {0}", headerOption.Value());
+                Verbose("Writing errorcode count to {0}", countOption.Value());
                 File.WriteAllText(countOption.Value(), errorFile.Count.ToString());
             }
 

--- a/src/Starcounter.ErrorCodes.Generator/CommandLineInterface.cs
+++ b/src/Starcounter.ErrorCodes.Generator/CommandLineInterface.cs
@@ -122,7 +122,7 @@ namespace Starcounter.ErrorCodes.Generator
 
             if (countOption.HasValue())
             {
-                Verbose("Writing errorcode count to {0]", headerOption.Value());
+                Verbose("Writing errorcode count to {0}", headerOption.Value());
                 File.WriteAllText(countOption.Value(), errorFile.Count.ToString());
             }
 

--- a/src/Starcounter.ErrorCodes/Starcounter.ErrorCodes.csproj
+++ b/src/Starcounter.ErrorCodes/Starcounter.ErrorCodes.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <Description>Library containing Starcounter errorcodes and utilities for creating and handling them.</Description>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard1.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">$(TargetFrameworks);net45;net46</TargetFrameworks>
+    <TargetFramework>netstandard1.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <SignAssembly>true</SignAssembly>

--- a/src/Starcounter.ErrorCodes/Starcounter.ErrorCodes.csproj
+++ b/src/Starcounter.ErrorCodes/Starcounter.ErrorCodes.csproj
@@ -11,7 +11,7 @@
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
 
     <!-- NOTE: VersionPrefix here should only contain Major.Minor version since the patchnúmber is calculated. -->
-    <VersionPrefix>0.16</VersionPrefix>
+    <VersionPrefix>0.17</VersionPrefix>
   </PropertyGroup>
 
   <Import Project="..\..\build\generate.props" />


### PR DESCRIPTION
Drop multi-targeting, since there's no functionality specific to .NET Framework, and netstandard1.0 is already consumable from Net45 and Net46, plus that there was some race conditions going on when building in parallel. Also fixed a couple of bugs.